### PR TITLE
Adiciona endpoint para listar todos os links encurtados

### DIFF
--- a/src/main/java/br/com/jonashcr/linkshortener/controllers/ShortLinkController.java
+++ b/src/main/java/br/com/jonashcr/linkshortener/controllers/ShortLinkController.java
@@ -37,6 +37,12 @@ public class ShortLinkController {
         return ResponseEntity.ok(shortLinkDTO);
     }
 
+    @GetMapping("/api/links")
+    public ResponseEntity<Iterable<ShortLink>> getAllLinks() {
+        Iterable<ShortLink> links = service.getAllLinks();
+        return ResponseEntity.ok(links);
+    }
+
     @GetMapping("/{shortCode}")
     public void redirect(@PathVariable String shortCode, HttpServletRequest req, HttpServletResponse res) throws IOException {
         if (req.getMethod().equalsIgnoreCase("HEAD")) {

--- a/src/main/java/br/com/jonashcr/linkshortener/services/ShortLinkService.java
+++ b/src/main/java/br/com/jonashcr/linkshortener/services/ShortLinkService.java
@@ -43,6 +43,10 @@ public class ShortLinkService {
         return Integer.toHexString(originalUrl.hashCode());
     }
 
+    public Iterable<ShortLink> getAllLinks() {
+        return shortLinkRepository.findAll();
+    }
+
     public ShortLink getByCode(String shortCode) {
         return shortLinkRepository.findByShortCode(shortCode)
                 .orElseThrow(() -> new RuntimeException("Short link não encontrado."));


### PR DESCRIPTION
## Descrição das alterações
Esta PR implementa um novo endpoint para listar todos os links encurtados cadastrados no sistema.

### Principais mudanças:
- Criação do endpoint GET /api/links no ShortLinkController
- Implementação do método getAllLinks no ShortLinkService
- Integração com o repositório para buscar todos os links

### Como testar:
1. Faça uma requisição GET para /api/links
   - Deve retornar um array com todos os links encurtados cadastrados
   - Cada item contém as informações completas do link (URL original, código curto, clicks)

### Impacto técnico:
- Adição de novo endpoint no controller
- Novo método de serviço para busca completa
- Não requer alterações no banco de dados

### Tipo de alteração
- [x] Nova funcionalidade (non-breaking change)
- [ ] Correção de bug
- [ ] Breaking change

### Documentação adicional
#### Endpoint
- **URL**: `/api/links`
- **Método**: GET 

