### PR TITLE
Adição de Testes Unitários e Configuração de Ambiente de Teste

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,23 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>5.3.1</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-junit-jupiter</artifactId>
+			<version>5.3.1</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/test/java/br/com/jonashcr/linkshortener/LinkshortenerApplicationTests.java
+++ b/src/test/java/br/com/jonashcr/linkshortener/LinkshortenerApplicationTests.java
@@ -1,13 +1,18 @@
 package br.com.jonashcr.linkshortener;
 
+import br.com.jonashcr.linkshortener.config.TestConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.context.annotation.Import;
 
 @SpringBootTest
+@ActiveProfiles("test")
+@Import(TestConfig.class)
 class LinkshortenerApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @Test
+    void contextLoads() {
+    }
 
 }

--- a/src/test/java/br/com/jonashcr/linkshortener/config/TestConfig.java
+++ b/src/test/java/br/com/jonashcr/linkshortener/config/TestConfig.java
@@ -1,0 +1,21 @@
+package br.com.jonashcr.linkshortener.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+import javax.sql.DataSource;
+
+@TestConfiguration
+public class TestConfig {
+
+    @Bean
+    public DataSource dataSource() {
+        DriverManagerDataSource dataSource = new DriverManagerDataSource();
+        dataSource.setDriverClassName("org.h2.Driver");
+        dataSource.setUrl("jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE");
+        dataSource.setUsername("sa");
+        dataSource.setPassword("");
+        return dataSource;
+    }
+}

--- a/src/test/java/br/com/jonashcr/linkshortener/services/ShortLinkServiceTest.java
+++ b/src/test/java/br/com/jonashcr/linkshortener/services/ShortLinkServiceTest.java
@@ -1,0 +1,120 @@
+package br.com.jonashcr.linkshortener.services;
+
+import br.com.jonashcr.linkshortener.domain.shortlink.ShortLink;
+import br.com.jonashcr.linkshortener.repositories.ShortLinkRepository;
+import br.com.jonashcr.linkshortener.infra.exceptions.InvalidUrlException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Optional;
+import java.util.List;
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+public class ShortLinkServiceTest {
+
+    @Mock
+    private ShortLinkRepository shortLinkRepository;
+
+    @InjectMocks
+    private ShortLinkService shortLinkService;
+
+    private ShortLink shortLink;
+    private final String validUrl = "https://www.google.com";
+    private final String invalidUrl = "invalid-url";
+
+    @BeforeEach
+    void setUp() {
+        shortLink = new ShortLink();
+        shortLink.setOriginalUrl(validUrl);
+        shortLink.setShortCode("abc123");
+        shortLink.setClicks(0);
+    }
+
+    @Test
+    void shouldCreateShortLink() {
+        when(shortLinkRepository.save(any(ShortLink.class))).thenReturn(shortLink);
+
+        ShortLink result = shortLinkService.createShortLink(validUrl);
+
+        assertNotNull(result);
+        assertEquals(validUrl, result.getOriginalUrl());
+        verify(shortLinkRepository).save(any(ShortLink.class));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenUrlIsInvalid() {
+        assertThrows(InvalidUrlException.class, () -> {
+            shortLinkService.createShortLink(invalidUrl);
+        });
+
+        verify(shortLinkRepository, never()).save(any());
+    }
+
+    @Test
+    void shouldThrowExceptionWhenUrlIsDuplicated() {
+        when(shortLinkRepository.save(any(ShortLink.class)))
+                .thenThrow(new DataIntegrityViolationException("Duplicate entry"));
+
+        Exception exception = assertThrows(RuntimeException.class, () -> {
+            shortLinkService.createShortLink(validUrl);
+        });
+
+        assertEquals("URL já cadastrada.", exception.getMessage());
+    }
+
+    @Test
+    void shouldGetLinkByCode() {
+        when(shortLinkRepository.findByShortCode("abc123")).thenReturn(Optional.of(shortLink));
+
+        ShortLink result = shortLinkService.getByCode("abc123");
+
+        assertNotNull(result);
+        assertEquals(shortLink.getOriginalUrl(), result.getOriginalUrl());
+    }
+
+    @Test
+    void shouldThrowExceptionWhenLinkNotFound() {
+        when(shortLinkRepository.findByShortCode("notfound")).thenReturn(Optional.empty());
+
+        Exception exception = assertThrows(RuntimeException.class, () -> {
+            shortLinkService.getByCode("notfound");
+        });
+
+        assertEquals("Short link não encontrado.", exception.getMessage());
+    }
+
+    @Test
+    void shouldIncrementClicks() {
+        shortLink.setClicks(5);
+
+        shortLinkService.incrementClicks(shortLink);
+
+        assertEquals(6, shortLink.getClicks());
+        verify(shortLinkRepository).save(shortLink);
+    }
+
+    @Test
+    void shouldReturnAllLinks() {
+        List<ShortLink> links = new ArrayList<>();
+        links.add(shortLink);
+        when(shortLinkRepository.findAll()).thenReturn(links);
+
+        Iterable<ShortLink> result = shortLinkService.getAllLinks();
+
+        assertNotNull(result);
+        assertTrue(result.iterator().hasNext());
+        verify(shortLinkRepository).findAll();
+    }
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,9 @@
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.username=sa
+spring.datasource.password=
+spring.datasource.driver-class-name=org.h2.Driver
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
+spring.jpa.properties.hibernate.format_sql=true


### PR DESCRIPTION
## Descrição
Este PR adiciona uma suite completa de testes unitários para o serviço ShortLinkService e configura um ambiente de testes isolado usando H2 como banco de dados em memória.

## Mudanças Realizadas

### Testes Unitários (ShortLinkServiceTest)
- Implementação de testes para validar a criação de links curtos
- Testes de validação de URLs inválidas
- Testes para tratamento de URLs duplicadas
- Cobertura de testes para busca de links por código
- Testes para o incremento de clicks
- Validação do comportamento quando um link não é encontrado
- Testes para listagem de todos os links

### Configuração do Ambiente de Teste
- Adição do banco H2 para testes em memória
- Configuração específica para ambiente de teste (application-test.properties)
- Implementação de TestConfig para fornecer DataSource de teste
- Configuração adequada do Hibernate para testes

## Como Testar
Os testes podem ser executados através do comando:
```bash
mvn test
``` 

## Impacto
- Maior confiabilidade no código através de testes automatizados
- Ambiente de teste isolado que não afeta o banco de dados de desenvolvimento
- Cobertura de testes para os principais fluxos do serviço

## Checklist

- [X] Testes unitários implementados
- [X] Ambiente de teste configurado
- [X] Testes executando com sucesso
- [X] Cobertura de casos de sucesso e erro
- [X] Configuração do H2 implementada